### PR TITLE
테일윈드4에서 샤드cn의 CSS 변수 기반 스타일이 적용되지 않는 문제

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "css.lint.unknownAtRules": "ignore",
+  "scss.lint.unknownAtRules": "ignore",
+  "postcss.validation": false
+}


### PR DESCRIPTION
## 🐞 버그 설명

테일윈드4에서 샤드cn의 CSS 변수 기반 스타일이 적용되지 않는 문제

## 📌 재현 방법

### 어떤 환경에서 발생했는지? (브라우저, OS 등)
### 버그를 재현하는 단계
 1. 테일윈드4가 설치된 상태에서 샤드cn 설치  
 2. 샤드cn의 버튼 컴포넌트 사용

## ✅ 기대한 동작

샤드cn의 --radius, --background, --foreground 등 CSS 변수를 활용한 버튼 스타일이 정상적으로 렌더링
<img width="91" alt="Image" src="https://github.com/user-attachments/assets/24f9f812-36b3-4590-9126-8fc188857f0f" />

## 📷 스크린샷
버그가 발생한 화면  
<img width="73" alt="Image" src="https://github.com/user-attachments/assets/054488c8-76e2-4b15-94dd-150863d49f47" />

## 📚 추가 정보

테일윈드 v4에서는 `tailwind.config.js` 없이 CSS-first 방식`(@theme, @custom-variant, :root)`으로 스타일 정의가 가능해졌지만, 샤드cn은 여전히 `tailwind.config.js` 기반 변수 확장을 요구함.
이로 인해 CSS 변수가 전역으로 선언되지 않거나 적용 우선순위가 누락되며 스타일이 제대로 반영되지 않는 것으로 추정

Closes #1